### PR TITLE
backend の app に適切なパーミッションを与える

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,7 +23,8 @@ COPY startup.sh /startup.sh
 RUN chmod 777 /startup.sh
 
 RUN groupadd -g 1002 app \
-  && useradd -m -u 1001 -g 1002 app
+  && useradd -m -u 1001 -g 1002 app \
+  && chown -R app:app /api
 USER app
 
 CMD ["/startup.sh"]


### PR DESCRIPTION
`app` の owner が root のままで動かなかったので、`app:app` に変更