### PR TITLE
backend/Dockerfile の ruby version を固定

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:latest
+FROM ruby:3.2.2
 
 ARG RUBYGEMS_VERSION=3.4.19
 
@@ -10,8 +10,8 @@ COPY Gemfile /api/Gemfile
 
 COPY Gemfile.lock /api/Gemfile.lock
 
-RUN gem update --system ${RUBYGEMS_VERSION} && \
-    bundle install
+RUN gem update --system ${RUBYGEMS_VERSION} \
+  && bundle install
 
 COPY . /api
 


### PR DESCRIPTION
backend/Dockerfile の image に `ruby:latest` が使用されていたが、Gemfile の ruby version とずれないように ruby:3.2.2 に変更した